### PR TITLE
Fix callbacks still being called after destroy()

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,11 +81,14 @@ module.exports = function(audioContext, stream, opts) {
 
   function disconnect() {
     scriptProcessorNode.disconnect();
+    analyser.disconnect();
+    source.disconnect();
   }
 
   function destroy() {
     captureTimeout && clearTimeout(captureTimeout);
     disconnect();
+    scriptProcessorNode.onaudioprocess = null;
   }
 
   function monitor() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voice-activity-detection",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Mic input activity detection",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Merely disconnecting the `ScriptProcessorNode` doesn't seem to be sufficient to stop it from processing further audio data (testing on Firefox 55).

The `connect()` function connects all nodes used, so this PR changes the `disconnect()` to also disconnect all nodes used.
Also, for good measure, to guarantee that absolutely no further events are emitted, the script processor's event handler is `null`ed when `destroy()` is called.